### PR TITLE
Updating allowed versions of `BlockArrays` and `Makie`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,9 +12,9 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 TrajectoryGamesBase = "ac1ac542-73eb-4349-ae1b-660ab3609574"
 
 [compat]
-BlockArrays = "0.16"
+BlockArrays = "0.16, 1"
 Colors = "0.12"
 InfiniteArrays = "0.12, 0.13, 0.14"
-Makie = "0.17, 0.18, 0.19, 0.20, 0.21"
+Makie = "0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24"
 TrajectoryGamesBase = "0.2, 0.3"
 julia = "1.7"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TrajectoryGamesExamples"
 uuid = "ff3fa34c-8d8f-519c-b5bc-31760c52507a"
 authors = ["David Fridovich-Keil<dfk@utexas.edu>", "Forrest Laine<forrest.laine@vanderbilt.edu>", "Lasse Peters<lasse.peters@mailbox.org>"]
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"


### PR DESCRIPTION
...resolves dependency version conflicts in downstream packages, ultimately allowing upgrades to `Symbolics v7.x`.